### PR TITLE
Use HTTPS when fetching exchange rates

### DIFF
--- a/lib/money/bank/open_exchange_rates_loader.rb
+++ b/lib/money/bank/open_exchange_rates_loader.rb
@@ -7,8 +7,8 @@ require 'open-uri'
 class Money
   module Bank
     module OpenExchangeRatesLoader
-      HIST_URL = 'http://openexchangerates.org/api/historical/'
-      OER_URL = 'http://openexchangerates.org/api/latest.json'
+      HIST_URL = 'https://openexchangerates.org/api/historical/'
+      OER_URL = 'https://openexchangerates.org/api/latest.json'
 
       # Tries to load data from OpenExchangeRates for the given rate.
       # Won't do anything if there's no data available for that date


### PR DESCRIPTION
OpenExchange.org recently launched a new infrastructure and it seems that they sometimes redirect HTTP traffic to HTTPS. When this happens an error is raised in OpenURI that makes the hirstorical_bank gem crash. To fix this, the URL should be the HTTPS URL.